### PR TITLE
Made a custom style and light theme optional

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -363,6 +363,8 @@ options_templates.update(options_section(('extra_networks', "Extra Networks"), {
 }))
 
 options_templates.update(options_section(('ui', "User interface"), {
+    "load_usercss": OptionInfo(True, "Use a custom style (user.css) instead of default Gradio style"),
+    "load_light_theme": OptionInfo(True, "Use a light theme. Not recommended with a custom style enabled"),
     "return_grid": OptionInfo(True, "Show grid in results for web"),
     "return_mask": OptionInfo(False, "For inpainting, include the greyscale mask in results for web"),
     "return_mask_composite": OptionInfo(False, "For inpainting, include masked composite in results for web"),

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1710,7 +1710,9 @@ def javascript_html():
 
     # inline = f"{localization.localization_js(shared.opts.localization)};"
     inline = ''
-    if cmd_opts.theme is not None:
+    if opts.load_light_theme:
+        inline += f"set_theme('light');"
+    elif cmd_opts.theme is not None:
         inline += f"set_theme('{cmd_opts.theme}');"
 
     for script in modules.scripts.list_scripts("javascript", ".js"):
@@ -1736,7 +1738,7 @@ def css_html():
 
         head += stylesheet(cssfile)
 
-    if os.path.exists(os.path.join(data_path, "user.css")):
+    if  opts.load_usercss and os.path.exists(os.path.join(data_path, "user.css")):
         head += stylesheet(os.path.join(data_path, "user.css"))
 
     return head


### PR DESCRIPTION
## Description

Added two options in Settings - User Interface:
- Use a custom style (user.css) instead of default Gradio style
- Use a light theme. Not recommended with a custom style enabled

## Environment and Testing

tested in Chrome & Firefox on Windows 11